### PR TITLE
Python version trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ kwargs = dict(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
Hello! Was wondering if Python version classifiers could be added so that `pytzdata` can be detected properly by services like pyup.io as to whether this module is Python 3 ready.

At a minimum:
```python
'Programming Language :: Python :: 2',
'Programming Language :: Python :: 3'
```

This would require a new push to pypi but I'm sure something minor like this can wait if a new release isn't planned.